### PR TITLE
feat(order) : OrderService, external platform on successful payment

### DIFF
--- a/src/services/order/order.entity.ts
+++ b/src/services/order/order.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Order {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+}

--- a/src/services/order/order.service.spec.ts
+++ b/src/services/order/order.service.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrderService } from './order.service';
+import { BalanceService } from '../balance/balance.service';
+import { EntityManager, Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { User } from '../user/user.entity';
+import { Product } from '../product/product.entity';
+import { Order } from './order.entity';
+import { ProductService } from '../product/product.service';
+
+describe('OrderService', () => {
+  let orderService: OrderService;
+  let entityManager: EntityManager;
+  let userRepository: Repository<User>;
+  let productRepository: Repository<Product>;
+  let balanceService: BalanceService;
+  let productService: ProductService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrderService,
+        BalanceService,
+        ProductService,
+        {
+          provide: getRepositoryToken(User),
+          useClass: Repository,
+        },
+        {
+          provide: getRepositoryToken(Product),
+          useClass: Repository,
+        },
+        {
+          provide: getRepositoryToken(Order),
+          useClass: Repository,
+        },
+      ],
+    }).compile();
+
+    orderService = module.get<OrderService>(OrderService);
+    entityManager = module.get<EntityManager>(EntityManager);
+    userRepository = module.get<Repository<User>>(getRepositoryToken(User));
+    productRepository = module.get<Repository<Product>>(
+      getRepositoryToken(Product),
+    );
+    balanceService = module.get<BalanceService>(BalanceService);
+    productService = module.get<ProductService>(ProductService);
+  });
+
+  describe('createOrder', () => {
+    it('should create an order successfully', async () => {
+      // Mock the necessary methods and services
+      jest.spyOn(balanceService, 'getBalance').mockResolvedValue(1000);
+      jest.spyOn(productService, 'getProductById').mockResolvedValue({
+        id: 1,
+        name: 'Product 1',
+        price: 50,
+        quantity: 10,
+      });
+
+      jest
+        .spyOn(entityManager, 'transaction')
+        .mockImplementation(async (cb) => {
+          const result = await cb(entityManager);
+
+          // Assuming you have a method to create a mock order
+          jest.spyOn(entityManager, 'save').mockResolvedValue(result);
+
+          return result;
+        });
+
+      // Assuming you have a method to create a mock order
+      const mockOrder = {
+        id: 1,
+        userId: 1,
+        items: [{ productId: 1, quantity: 2 }],
+        totalAmount: 100,
+      };
+
+      // Call the createOrder method
+      const createdOrder = await orderService.createOrder(1, [
+        { productId: 1, quantity: 2 },
+      ]);
+
+      // Assertions
+      expect(createdOrder).toEqual(mockOrder);
+
+      // Optionally, you can add more assertions based on your specific logic
+    });
+  });
+
+  // Add more test cases for other methods as needed
+
+});

--- a/src/services/order/order.service.ts
+++ b/src/services/order/order.service.ts
@@ -1,0 +1,138 @@
+import { Injectable } from '@nestjs/common';
+import { BalanceService } from '../balance/balance.service';
+import { EntityManager, Repository } from 'typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import type { DataSource } from 'typeorm';
+import { User } from '../user/user.entity';
+import { Product } from '../product/product.entity';
+import { Order } from './order.entity';
+import { ProductService } from '../product/product.service';
+
+@Injectable()
+export class OrderService {
+  constructor(
+    @InjectDataSource() protected dataSource: DataSource,
+    @InjectRepository(Order)
+    private ordersRepository: Repository<Order>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(Product)
+    private readonly productRepository: Repository<Product>,
+    private readonly balanceService: BalanceService,
+    private readonly productService: ProductService,
+  ) {}
+
+  async getBalance(userId: string): Promise<number> {
+    return this.balanceService.getBalance(userId);
+  }
+
+  async createOrder(
+    userId: number,
+    products: { productId: number; quantity: number }[],
+  ): Promise<Order> {
+    // 트랜잭션 시작
+    const result = await this.dataSource.transaction(
+      async (transactionalEntityManager) => {
+        const order = new Order(); // Create an instance of the Order entity
+
+        for (const product of products) {
+          const { productId, quantity } = product;
+          await this.deductInventory(
+            transactionalEntityManager,
+            productId,
+            quantity,
+          );
+        }
+
+        const totalAmount = await this.calculateTotalAmount(products);
+        await this.deductAmountFromBalance(
+          transactionalEntityManager,
+          userId,
+          totalAmount,
+        );
+
+        // Save the order to the database
+        return transactionalEntityManager.save(Order, order);
+      },
+    );
+    return result;
+  }
+
+  sendOrderToDataPlatform(orderId: number): void {
+    // Mock implementation of sending order information to data platform
+    console.log('Sending order information to data platform:', orderId);
+  }
+
+  private async deductAmountFromBalance(
+    entityManager: EntityManager,
+    userId: number,
+    amount: number,
+  ): Promise<void> {
+    await entityManager.update(User, userId, {
+      balance: () => `balance - ${amount}`,
+    });
+  }
+
+  private async deductInventory(
+    entityManager: EntityManager,
+    productId: number,
+    quantity: number,
+  ): Promise<void> {
+    // Retrieve the product from the database
+    const product = await entityManager.findOne(Product, {
+      where: { id: productId },
+    });
+
+    if (!product) {
+      throw new Error(`Product with ID ${productId} not found`);
+    }
+
+    // Check if there's enough inventory
+    if (product.inventory < quantity) {
+      throw new Error(`Not enough inventory for product ${productId}`);
+    }
+
+    // Deduct the inventory
+    product.inventory -= quantity;
+
+    // Save the updated product to the database
+    await entityManager.save(Product, product);
+
+    // 여기에서 상품의 재고를 차감하는 로직을 추가
+    // transactionalEntityManager를 사용하여 트랜잭션 내에서 데이터베이스 조작을 수행
+    await entityManager.update(Product, productId, {
+      inventory: () => `inventory - ${quantity}`,
+    });
+  }
+
+  private async calculateTotalAmount(
+    products: { productId: number; quantity: number }[],
+  ): Promise<number> {
+    let totalAmount = 0;
+
+    for (const product of products) {
+      const { productId, quantity } = product;
+
+      // Get product details by calling getProductById from ProductService
+      const productDetails =
+        await this.productService.getProductById(productId);
+
+      // Check if the product is found
+      if (productDetails) {
+        // Calculate the total amount based on product price and quantity
+        totalAmount += productDetails.price * quantity;
+      }
+    }
+
+    return totalAmount;
+  }
+
+  private createOrderInfo(
+    userId: string,
+    items: { productId: number; quantity: number }[],
+    totalAmount: number,
+  ): any {
+    // Implementation of creating order information object
+    return { userId, items, totalAmount };
+  }
+}

--- a/src/shared/external.service.ts
+++ b/src/shared/external.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import axios from 'axios';
+
+@Injectable()
+export class ExternalDataService {
+  async sendPaymentStatus(orderId: string, success: boolean): Promise<void> {
+    const externalPlatformUrl =
+      'https://external-platform.com/api/payment/status';
+
+    try {
+      await axios.post(externalPlatformUrl, { orderId, success });
+    } catch (error) {
+      console.error(
+        `Failed to send payment status to external platform for order ${orderId}`,
+        error,
+      );
+      throw new Error('Failed to communicate with external platform');
+    }
+  }
+}


### PR DESCRIPTION
- 외부 플랫폼 호출하는 함수의 위치를 shared에 두는 것이 맞을까 ? services/order 내부에 두는 것이 좋을까 ?

외부 플랫폼 호출 함수를 shared 모듈에 위치시키는 경우:
장점:
재사용성 향상: 다른 서비스나 모듈에서도 동일한 외부 플랫폼 호출 함수를 사용할 수 있습니다.

모듈 간의 결합도 감소: shared 모듈은 여러 서비스에서 공유되므로, 각 서비스 간의 결합도가 낮아집니다.

단점:
컨텍스트 이동: 외부 호출 함수가 shared 모듈에 위치하면 해당 함수가 사용되는 서비스에서 컨텍스트 이동이 필요합니다. 즉, 외부 호출 함수를 사용하는 서비스가 어떤 서비스인지 명확하지 않을 수 있습니다.
외부 플랫폼 호출 함수를 services/order 내부에 위치시키는 경우:
장점:
명시성: 외부 호출 함수가 services/order에 위치하면 해당 서비스의 컨텍스트 내에서 명시적으로 사용됩니다. 어떤 서비스에서 어떤 외부 호출을 하는지 명확합니다.

컨텍스트 일치: 외부 호출 함수는 특정 주문 서비스와 관련이 있으므로, 관련 코드와 함께 위치시키면 컨텍스트 일치가 더 잘 이루어집니다.

단점:
재사용 어려움: 다른 서비스에서 동일한 외부 호출을 해야 하는 경우에는 코드 중복이 발생할 수 있습니다.

결합도 증가: services/order 내부에 위치한 경우, 다른 서비스에서 해당 함수를 사용하려면 직접 참조해야 합니다. 이로 인해 서비스 간의 결합도가 증가할 수 있습니다.

결론:
재사용성이 중요하다면 외부 플랫폼 호출 함수를 shared 모듈에 위치시키는 것이 좋습니다.

명시성과 컨텍스트 일치가 중요하다면 해당 서비스 내부에 위치시키는 것이 좋습니다.